### PR TITLE
Implement precedence-based parser

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -17,9 +17,9 @@ def assert_token_sequence(sequence : Array(LC::Token::Kind), for input : String)
   kinds.should eq sequence
 end
 
-def parse(source : String) : Array(LC::Node)
+def parse(source : String) : Array(LC::Expression)
   tokens = LC::Lexer.run source
-  LC::Parser.parse tokens
+  LC::Parser.parse(tokens).map &.value
 end
 
 def assert_node(cls : LC::Node.class, for input : String) : Nil

--- a/src/compiler/node.cr
+++ b/src/compiler/node.cr
@@ -14,27 +14,33 @@ module Lucid::Compiler
     abstract def inspect(io : IO) : Nil
   end
 
-  class Expressions < Node
-    property expressions : Array(Node)
+  abstract class Statement < Node
+  end
 
-    def initialize(@expressions : Array(Node))
+  abstract class Expression < Node
+  end
+
+  class ExpressionStatement < Statement
+    property value : Expression
+
+    def initialize(@value : Expression)
       super()
     end
 
     def to_s(io : IO) : Nil
       io << '('
-      @expressions.each &.to_s(io)
+      @value.to_s io
       io << ')'
     end
 
     def inspect(io : IO) : Nil
-      io << "Expressions("
-      @expressions.each &.inspect(io)
+      io << "ExpressionStatement("
+      @value.inspect io
       io << ')'
     end
   end
 
-  class Path < Node
+  class Path < Expression
     property names : Array(Ident)
     property? global : Bool
 
@@ -62,7 +68,7 @@ module Lucid::Compiler
     end
   end
 
-  class Ident < Node
+  class Ident < Expression
     property value : String
     property? global : Bool
 
@@ -91,13 +97,13 @@ module Lucid::Compiler
     end
   end
 
-  class Var < Node
+  class Var < Expression
     property name : Node
     property type : Node?
     property value : Node?
 
     def initialize(@name : Node, @type : Node?, @value : Node?)
-      super() # needs investigating
+      super()
     end
 
     def uninitialized? : Bool
@@ -132,8 +138,8 @@ module Lucid::Compiler
   class ClassVar < Var
   end
 
-  class Prefix < Node
-    enum Kind
+  class Prefix < Expression
+    enum Operator
       Plus        # +
       Minus       # -
       Splat       # *
@@ -160,11 +166,10 @@ module Lucid::Compiler
       end
     end
 
-    property op : Kind
+    property op : Operator
     property value : Node
 
-    def initialize(op : Token::Kind, @value : Node)
-      @op = Kind.from op
+    def initialize(@op : Operator, @value : Node)
       super()
     end
 
@@ -180,8 +185,8 @@ module Lucid::Compiler
     end
   end
 
-  class Infix < Node
-    enum Kind
+  class Infix < Expression
+    enum Operator
       Add      # +
       Subtract # -
       Multiply # *
@@ -214,12 +219,11 @@ module Lucid::Compiler
       end
     end
 
-    property op : Kind
+    property op : Operator
     property left : Node
     property right : Node
 
-    def initialize(op : Token::Kind, @left : Node, @right : Node)
-      @op = Kind.from op
+    def initialize(@op : Operator, @left : Node, @right : Node)
       super()
     end
 
@@ -238,7 +242,7 @@ module Lucid::Compiler
     end
   end
 
-  class Assign < Node
+  class Assign < Expression
     property target : Node
     property value : Node
 
@@ -259,7 +263,7 @@ module Lucid::Compiler
     end
   end
 
-  class Call < Node
+  class Call < Expression
     property receiver : Node
     property args : Array(Node)
 
@@ -282,7 +286,7 @@ module Lucid::Compiler
     end
   end
 
-  class StringLiteral < Node
+  class StringLiteral < Expression
     property value : String
 
     def initialize(@value : String)
@@ -300,7 +304,7 @@ module Lucid::Compiler
     end
   end
 
-  class IntLiteral < Node
+  class IntLiteral < Expression
     property raw : String
     property value : Int64
 
@@ -320,7 +324,7 @@ module Lucid::Compiler
     end
   end
 
-  class FloatLiteral < Node
+  class FloatLiteral < Expression
     property raw : String
     property value : Float64
 
@@ -340,7 +344,7 @@ module Lucid::Compiler
     end
   end
 
-  class BoolLiteral < Node
+  class BoolLiteral < Expression
     # ameba:disable Naming/QueryBoolMethods
     property value : Bool
 
@@ -357,7 +361,7 @@ module Lucid::Compiler
     end
   end
 
-  class NilLiteral < Node
+  class NilLiteral < Expression
     def to_s(io : IO) : Nil
       io << "nil"
     end

--- a/src/compiler/node.cr
+++ b/src/compiler/node.cr
@@ -11,7 +11,7 @@ module Lucid::Compiler
     end
 
     abstract def to_s(io : IO) : Nil
-    abstract def inspect(io : IO) : Nil
+    abstract def pretty_print(pp : PrettyPrint) : Nil
   end
 
   abstract class Statement < Node
@@ -33,10 +33,11 @@ module Lucid::Compiler
       io << ')'
     end
 
-    def inspect(io : IO) : Nil
-      io << "ExpressionStatement("
-      @value.inspect io
-      io << ')'
+    def pretty_print(pp : PrettyPrint) : Nil
+      pp.text "ExpressionStatement("
+      pp.breakable ""
+      pp.nest { @value.pretty_print pp }
+      pp.text ")"
     end
   end
 
@@ -61,10 +62,30 @@ module Lucid::Compiler
       end
     end
 
-    def inspect(io : IO) : Nil
-      io << "Path(names: "
-      io << @names << ", global: "
-      io << @global << ')'
+    def pretty_print(pp : PrettyPrint) : Nil
+      pp.text "Path("
+      pp.group 1 do
+        pp.breakable ""
+        pp.text "names: ["
+        pp.group 1 do
+          pp.breakable ""
+          next if @names.empty?
+
+          @names[0].pretty_print pp
+          if @names.size > 1
+            @names.skip(1).each do |name|
+              pp.comma
+              name.pretty_print pp
+            end
+          end
+        end
+        pp.text "]"
+
+        pp.comma
+        pp.text "global: "
+        pp.text @global
+      end
+      pp.text ")"
     end
   end
 
@@ -80,20 +101,34 @@ module Lucid::Compiler
       io << @value
     end
 
-    def inspect(io : IO) : Nil
-      io << "Ident(value: "
-      @value.inspect io
-      io << ", global: "
-      io << @global << ')'
+    def pretty_print(pp : PrettyPrint) : Nil
+      pp.text "Ident("
+      pp.group 1 do
+        pp.breakable ""
+        pp.text "value: "
+        pp.text @value.inspect
+        pp.comma
+
+        pp.text "global: "
+        pp.text @global
+      end
+      pp.text ")"
     end
   end
 
   class Const < Ident
-    def inspect(io : IO) : Nil
-      io << "Const(value: "
-      @value.inspect io
-      io << ", global: "
-      io << @global << ')'
+    def pretty_print(pp : PrettyPrint) : Nil
+      pp.text "Const("
+      pp.group 1 do
+        pp.breakable ""
+        pp.text "value: "
+        pp.text @value.inspect
+        pp.comma
+
+        pp.text "global: "
+        pp.text @global
+      end
+      pp.text ")"
     end
   end
 
@@ -121,14 +156,22 @@ module Lucid::Compiler
       end
     end
 
-    def inspect(io : IO) : Nil
-      io << "Var(name: "
-      @name.inspect io
-      io << ", type: "
-      @type.inspect io
-      io << ", value: "
-      @value.inspect io
-      io << ')'
+    def pretty_print(pp : PrettyPrint) : Nil
+      pp.text "Var("
+      pp.group 1 do
+        pp.breakable ""
+        pp.text "name: "
+        pp.text @name
+        pp.comma
+
+        pp.text "type: "
+        pp.text @type
+        pp.comma
+
+        pp.text "value: "
+        pp.text @value
+      end
+      pp.text ")"
     end
   end
 
@@ -177,11 +220,18 @@ module Lucid::Compiler
       io << @op << @value
     end
 
-    def inspect(io : IO) : Nil
-      io << "Prefix(op: '" << @op
-      io << "', value: "
-      @value.inspect io
-      io << ')'
+    def pretty_print(pp : PrettyPrint) : Nil
+      pp.text "Prefix("
+      pp.group 1 do
+        pp.breakable ""
+        pp.text "op: "
+        pp.text @op
+        pp.comma
+
+        pp.text "value: "
+        @value.pretty_print pp
+      end
+      pp.text ")"
     end
   end
 
@@ -231,14 +281,22 @@ module Lucid::Compiler
       io << @left << ' ' << @op << ' ' << @right
     end
 
-    def inspect(io : IO) : Nil
-      io << "Infix(left: "
-      @left.inspect io
-      io << ", op: "
-      @op.inspect io
-      io << ", right: "
-      @right.inspect io
-      io << ')'
+    def pretty_print(pp : PrettyPrint) : Nil
+      pp.text "Infix("
+      pp.group 1 do
+        pp.breakable ""
+        pp.text "left: "
+        @left.pretty_print pp
+        pp.comma
+
+        pp.text "op: "
+        pp.text @op
+        pp.comma
+
+        pp.text "right: "
+        @right.pretty_print pp
+      end
+      pp.text ")"
     end
   end
 
@@ -254,12 +312,18 @@ module Lucid::Compiler
       io << @target << " = " << @value
     end
 
-    def inspect(io : IO) : Nil
-      io << "Assign(target: "
-      @target.inspect io
-      io << ", value: "
-      @value.inspect io
-      io << ')'
+    def pretty_print(pp : PrettyPrint) : Nil
+      pp.text "Assign("
+      pp.group 1 do
+        pp.breakable ""
+        pp.text "target: "
+        @target.pretty_print pp
+        pp.comma
+
+        pp.text "value: "
+        @value.pretty_print pp
+      end
+      pp.text ")"
     end
   end
 
@@ -277,12 +341,30 @@ module Lucid::Compiler
       io << ')'
     end
 
-    def inspect(io : IO) : Nil
-      io << "Call(receiver: "
-      @receiver.inspect io
-      io << ", args: "
-      @args.inspect io
-      io << ')'
+    def pretty_print(pp : PrettyPrint) : Nil
+      pp.text "Call("
+      pp.group 1 do
+        pp.breakable ""
+        pp.text "receiver: "
+        @receiver.pretty_print pp
+
+        pp.comma
+        pp.text "args: ["
+        pp.group 1 do
+          pp.breakable ""
+          next if @args.empty?
+
+          @args[0].pretty_print pp
+          if @args.size > 1
+            @args.skip(1).each do |arg|
+              pp.comma
+              arg.pretty_print pp
+            end
+          end
+        end
+        pp.text "]"
+      end
+      pp.text ")"
     end
   end
 
@@ -297,10 +379,10 @@ module Lucid::Compiler
       @value.inspect io
     end
 
-    def inspect(io : IO) : Nil
-      io << "StringLiteral("
-      @value.inspect io
-      io << ')'
+    def pretty_print(pp : PrettyPrint) : Nil
+      pp.text "StringLiteral("
+      pp.text @value.inspect
+      pp.text ")"
     end
   end
 
@@ -317,10 +399,10 @@ module Lucid::Compiler
       io << @value
     end
 
-    def inspect(io : IO) : Nil
-      io << "IntLiteral("
-      @value.inspect io
-      io << ')'
+    def pretty_print(pp : PrettyPrint) : Nil
+      pp.text "IntLiteral("
+      pp.text @value.inspect
+      pp.text ")"
     end
   end
 
@@ -337,10 +419,10 @@ module Lucid::Compiler
       io << @value
     end
 
-    def inspect(io : IO) : Nil
-      io << "FloatLiteral("
-      @value.inspect io
-      io << ')'
+    def pretty_print(pp : PrettyPrint) : Nil
+      pp.text "FloatLiteral("
+      pp.text @value.inspect
+      pp.text ")"
     end
   end
 
@@ -356,8 +438,10 @@ module Lucid::Compiler
       io << @value
     end
 
-    def inspect(io : IO) : Nil
-      io << "BoolLiteral(" << @value << ')'
+    def pretty_print(pp : PrettyPrint) : Nil
+      pp.text "BoolLiteral("
+      pp.text @value
+      pp.text ")"
     end
   end
 
@@ -366,8 +450,8 @@ module Lucid::Compiler
       io << "nil"
     end
 
-    def inspect(io : IO) : Nil
-      io << "NilLiteral"
+    def pretty_print(pp : PrettyPrint) : Nil
+      pp.text "NilLiteral"
     end
   end
 end

--- a/src/compiler/parser.cr
+++ b/src/compiler/parser.cr
@@ -132,10 +132,6 @@ module Lucid::Compiler
       if token.operator?
         return parse_infix_expression token, expr
       end
-
-      if token.kind.left_paren?
-        return parse_call expr, true
-      end
     end
 
     private def parse_infix_expression(token : Token, left : Expression) : Expression
@@ -312,10 +308,9 @@ module Lucid::Compiler
 
     private def parse_grouped_expression : Expression
       expr = parse_expression next_token_skip_space!, :lowest
-      # FIXME: figure out why parse_expression is still skipping ahead
-      token = @tokens[@pos]? || raise "unexpected EOF"
+      token = next_token?
 
-      unless token.kind.right_paren?
+      if token.nil? || !token.kind.right_paren?
         raise "expected closing parenthesis after expression"
       end
 

--- a/src/compiler/token.cr
+++ b/src/compiler/token.cr
@@ -15,18 +15,18 @@ module Lucid::Compiler
       False
       Nil
 
-      LeftParen
-      RightParen
-      Colon
-      DoubleColon
-      Comma
-      Period
+      LeftParen   # (
+      RightParen  # )
+      Colon       # :
+      DoubleColon # ::
+      Comma       # ,
+      Period      # .
 
       Plus        # +
       Minus       # -
       Star        # *
-      Slash       # /
       DoubleStar  # **
+      Slash       # /
       DoubleSlash # //
 
       Assign            # =
@@ -35,12 +35,12 @@ module Lucid::Compiler
       PlusAssign        # +=
       MinusAssign       # -=
       StarAssign        # *=
-      SlashAssign       # /=
       DoubleStarAssign  # **=
+      SlashAssign       # /=
       DoubleSlashAssign # //=
 
-      IsA
-      RespondsTo
+      IsA        # is_a?
+      RespondsTo # responds_to?
 
       Module
       Enum
@@ -48,6 +48,10 @@ module Lucid::Compiler
       Class
       Def
       End
+
+      def is_nil? : Bool
+        self == Kind::Nil
+      end
     end
 
     getter kind : Kind
@@ -65,7 +69,7 @@ module Lucid::Compiler
     end
 
     def operator? : Bool
-      @kind.in?(Kind::Plus..Kind::DoubleSlashAssign)
+      @kind.in?(Kind::Plus..Kind::DoubleSlash)
     end
 
     def assign? : Bool

--- a/src/compiler/token.cr
+++ b/src/compiler/token.cr
@@ -75,5 +75,32 @@ module Lucid::Compiler
     def assign? : Bool
       @kind.in?(Kind::Assign..Kind::DoubleSlashAssign)
     end
+
+    def to_s(io : IO) : Nil
+      if @value
+        @value.inspect io
+      else
+        io << @kind.to_s.underscore
+      end
+    end
+
+    def inspect(io : IO) : Nil
+      io << "Token(kind: "
+      @kind.inspect io
+
+      io << ", loc: "
+      line_start, line_end = @loc.line
+      io << line_start << ':' << line_end
+
+      col_start, col_end = @loc.column
+      io << '-' << col_start << ':' << col_end
+
+      if @value
+        io << ", value: "
+        @value.inspect io
+      end
+
+      io << ')'
+    end
   end
 end

--- a/src/compiler/token.cr
+++ b/src/compiler/token.cr
@@ -49,6 +49,7 @@ module Lucid::Compiler
       Def
       End
 
+      # ameba:disable Naming/PredicateName
       def is_nil? : Bool
         self == Kind::Nil
       end


### PR DESCRIPTION
This PR re-implements the entire parser to operate based on the precedence of tokens as well as introduces `Statement` and `Expression` node types to differentiate the constructs in Crystal. The `#inspect` methods on nodes have also been replaced with the much more readable `#pretty_print` methods. Closes #4.