### PR TITLE
Allow int/float values in tokens for parsing

### DIFF
--- a/src/compiler/lexer.cr
+++ b/src/compiler/lexer.cr
@@ -102,7 +102,7 @@ module Lucid::Compiler
           when 'L'
             if next_sequence?('I', 'N', 'E', '_', '_')
               next_char
-              Token.new :magic_line, location, (@line + 1).to_s
+              Token.new :magic_line, location, (@line + 1).to_i64
             else
               lex_ident start
             end
@@ -564,7 +564,7 @@ module Lucid::Compiler
         end
       end
 
-      value = read_string_from(start).to_i64(base: 8).to_s
+      value = read_string_from(start).to_i64(base: 8)
       Token.new kind, location, value
     end
 
@@ -585,7 +585,7 @@ module Lucid::Compiler
         end
       end
 
-      value = read_string_from(start).to_i64(base: 16).to_s
+      value = read_string_from(start).to_i64(base: 16)
       Token.new kind, location, value
     end
 
@@ -606,7 +606,7 @@ module Lucid::Compiler
         end
       end
 
-      value = read_string_from(start).to_i64(base: 2).to_s
+      value = read_string_from(start).to_i64(base: 2)
       Token.new kind, location, value
     end
 
@@ -662,7 +662,13 @@ module Lucid::Compiler
         end
       end
 
-      Token.new kind, location, read_string_from start
+      if kind.integer?
+        value = read_string_from(start).to_i64(strict: false)
+      else
+        value = read_string_from(start).to_f64(strict: false)
+      end
+
+      Token.new kind, location, value
     end
 
     private def read_string_from(start : Int32) : String

--- a/src/compiler/node.cr
+++ b/src/compiler/node.cr
@@ -683,12 +683,10 @@ module Lucid::Compiler
   end
 
   class IntLiteral < Expression
-    property raw : String
     property value : Int64
 
-    def initialize(@raw : String)
+    def initialize(@value : Int64)
       super()
-      @value = @raw.to_i64 strict: false
     end
 
     def to_s(io : IO) : Nil
@@ -703,12 +701,10 @@ module Lucid::Compiler
   end
 
   class FloatLiteral < Expression
-    property raw : String
     property value : Float64
 
-    def initialize(@raw : String)
+    def initialize(@value : Float64)
       super()
-      @value = @raw.to_f64 strict: false
     end
 
     def to_s(io : IO) : Nil

--- a/src/compiler/parser.cr
+++ b/src/compiler/parser.cr
@@ -472,7 +472,7 @@ module Lucid::Compiler
       if token.kind.self?
         names << Self.new("self", global).at(token.loc)
       else
-        names << Ident.new(token.value, global).at(token.loc)
+        names << Ident.new(token.str_value, global).at(token.loc)
       end
 
       while peek_token.kind.period?
@@ -480,7 +480,7 @@ module Lucid::Compiler
         token = next_token_skip space: true
 
         if token.kind.ident?
-          names << Ident.new(token.value, false).at(token.loc)
+          names << Ident.new(token.str_value, false).at(token.loc)
         else
           raise "unexpected token #{token}"
         end
@@ -495,7 +495,7 @@ module Lucid::Compiler
 
     # CONST ::= ('A'..'Z') ('a'..'z' | 'A'..'Z' | '0'..'9' | '_')*
     private def parse_const_or_path(token : Token, global : Bool) : Expression
-      names = [Const.new(token.value, global).at(token.loc)] of Ident
+      names = [Const.new(token.str_value, global).at(token.loc)] of Ident
       in_method = false
 
       while peek_token.kind.period? || peek_token.kind.double_colon?
@@ -507,10 +507,10 @@ module Lucid::Compiler
         case token.kind
         when .ident?
           in_method = true
-          names << Ident.new(token.value, global).at(token.loc)
+          names << Ident.new(token.str_value, global).at(token.loc)
         when .const?
           raise "unexpected token #{token}" if in_method
-          names << Const.new(token.value, global).at(token.loc)
+          names << Const.new(token.str_value, global).at(token.loc)
         else
           raise "unexpected token #{token}"
         end
@@ -604,15 +604,15 @@ module Lucid::Compiler
     end
 
     private def parse_integer(token : Token) : Expression
-      IntLiteral.new(token.value).at(token.loc)
+      IntLiteral.new(token.int_value).at(token.loc)
     end
 
     private def parse_float(token : Token) : Expression
-      FloatLiteral.new(token.value).at(token.loc)
+      FloatLiteral.new(token.float_value).at(token.loc)
     end
 
     private def parse_string(token : Token) : Expression
-      StringLiteral.new(token.value).at(token.loc)
+      StringLiteral.new(token.str_value).at(token.loc)
     end
 
     private def parse_bool(token : Token) : Expression

--- a/src/compiler/token.cr
+++ b/src/compiler/token.cr
@@ -115,16 +115,24 @@ module Lucid::Compiler
 
     getter kind : Kind
     getter loc : Location
-    @value : String?
+    @value : String | Int64 | Float64 | Nil
 
-    def initialize(@kind : Kind, @loc : Location, @value : String? = nil)
+    def initialize(@kind : Kind, @loc : Location, @value : String | Int64 | Float64 | Nil = nil)
     end
 
-    def value : String
+    def str_value : String
       @value.as(String)
     end
 
-    def value=(@value : String?)
+    def int_value : Int64
+      @value.as(Int64)
+    end
+
+    def float_value : Float64
+      @value.as(Float64)
+    end
+
+    def value=(@value : String | Int | Nil)
     end
 
     def operator? : Bool


### PR DESCRIPTION
This removes the additional conversions performed by the parser and nodes for integers/floats and will help with chars when implemented.