### PR TITLE
Flatten AST Nodes Structure

### DIFF
--- a/spec/parser/assign_and_vars_spec.cr
+++ b/spec/parser/assign_and_vars_spec.cr
@@ -3,7 +3,7 @@ require "../spec_helper"
 describe LC::Parser do
   context "assign and vars", tags: %w[parser assign vars] do
     it "parses assignment expressions" do
-      node = parse_expr "x = 7"
+      node = parse "x = 7"
       node.should be_a LC::Assign
       node = node.as(LC::Assign)
 
@@ -15,7 +15,7 @@ describe LC::Parser do
     end
 
     it "parses uninitialized variable declaration expressions" do
-      node = parse_expr "x : Int32"
+      node = parse "x : Int32"
       node.should be_a LC::Var
       node = node.as(LC::Var)
 
@@ -30,7 +30,7 @@ describe LC::Parser do
     end
 
     it "parses initialized variable declaration expressions" do
-      node = parse_expr "y : Int32 = 123"
+      node = parse "y : Int32 = 123"
       node.should be_a LC::Var
       node = node.as(LC::Var)
 

--- a/spec/parser/calls_and_paths_spec.cr
+++ b/spec/parser/calls_and_paths_spec.cr
@@ -3,7 +3,7 @@ require "../spec_helper"
 describe LC::Parser do
   context "calls and paths", tags: %w[parser calls paths] do
     it "parses call expressions with no arguments" do
-      node = parse_expr "exit"
+      node = parse "exit"
       node.should be_a LC::Call
       node = node.as(LC::Call)
 
@@ -13,7 +13,7 @@ describe LC::Parser do
     end
 
     it "parses delimited call expressions" do
-      {parse_expr("puts;"), parse_expr("puts\n")}.each do |node|
+      {parse("puts;"), parse("puts\n")}.each do |node|
         node.should be_a LC::Call
         node = node.as(LC::Call)
 
@@ -23,7 +23,7 @@ describe LC::Parser do
     end
 
     it "parses path call expressions" do
-      node = parse_expr "foo.bar.baz"
+      node = parse "foo.bar.baz"
       node.should be_a LC::Call
       node = node.as(LC::Call)
 
@@ -42,7 +42,7 @@ describe LC::Parser do
     end
 
     it "parses constant path expressions" do
-      node = parse_expr "Foo::Bar"
+      node = parse "Foo::Bar"
       node.should be_a LC::Path
       node = node.as(LC::Path)
 
@@ -57,7 +57,7 @@ describe LC::Parser do
     end
 
     it "parses constant call expresions" do
-      node = parse_expr "::Foo.baz"
+      node = parse "::Foo.baz"
       node.should be_a LC::Call
       node = node.as(LC::Call)
 
@@ -75,7 +75,7 @@ describe LC::Parser do
     end
 
     it "parses call expressions with single arguments" do
-      node = parse_expr %(puts "hello world")
+      node = parse %(puts "hello world")
       node.should be_a LC::Call
       node = node.as(LC::Call)
 
@@ -88,7 +88,7 @@ describe LC::Parser do
     end
 
     it "parses call expressions with multiple arguments" do
-      node = parse_expr %(puts "foo", "bar", "baz")
+      node = parse %(puts "foo", "bar", "baz")
       node.should be_a LC::Call
       node = node.as(LC::Call)
 
@@ -107,7 +107,7 @@ describe LC::Parser do
     end
 
     it "parses call expressions on multiple lines" do
-      node = parse_expr <<-CR
+      node = parse <<-CR
         puts(
           "hello from",
           "the other side",
@@ -129,7 +129,7 @@ describe LC::Parser do
     end
 
     it "parses nested call expressions" do
-      node = parse_expr <<-CR
+      node = parse <<-CR
         puts(
           "hello, ",
           your_name,
@@ -157,18 +157,18 @@ describe LC::Parser do
 
     it "raises on undelimited arguments for calls" do
       expect_raises(Exception, "expected a comma after the last argument") do
-        parse_expr %(puts "foo" "bar")
+        parse %(puts "foo" "bar")
       end
     end
 
     it "raises on unclosed parentheses for calls" do
       expect_raises(Exception, "expected closing parenthesis for call") do
-        parse_expr %[puts("foo", "bar"]
+        parse %[puts("foo", "bar"]
       end
     end
 
     it "parses call expressions with a single variable declaration" do
-      node = parse_expr "::property(name : String)"
+      node = parse "::property(name : String)"
 
       node.should be_a LC::Call
       node = node.as(LC::Call)
@@ -190,7 +190,7 @@ describe LC::Parser do
     end
 
     it "parses call expressions with a single variable assignment" do
-      node = parse_expr %(::property(name = "dev"))
+      node = parse %(::property(name = "dev"))
 
       node.should be_a LC::Call
       node = node.as(LC::Call)
@@ -211,7 +211,7 @@ describe LC::Parser do
     end
 
     it "parses call expressions with a single variable declaration and assignment" do
-      node = parse_expr %(::property(name : String = "dev"))
+      node = parse %(::property(name : String = "dev"))
 
       node.should be_a LC::Call
       node = node.as(LC::Call)
@@ -235,7 +235,7 @@ describe LC::Parser do
     end
 
     it "parses call expressions with multiple variable declarations" do
-      node = parse_expr "record Foo, bar : Int32, baz : String"
+      node = parse "record Foo, bar : Int32, baz : String"
 
       node.should be_a LC::Call
       node = node.as(LC::Call)
@@ -267,7 +267,7 @@ describe LC::Parser do
     end
 
     it "parses call expressions with multiple variable assignments" do
-      node = parse_expr %(record Foo, bar = 123, baz = "true")
+      node = parse %(record Foo, bar = 123, baz = "true")
 
       node.should be_a LC::Call
       node = node.as(LC::Call)
@@ -297,7 +297,7 @@ describe LC::Parser do
     end
 
     it "parses call expressions with multiple variable declarations and assignments" do
-      node = parse_expr %(record Foo, bar : Int32 = 123, baz : String = "true")
+      node = parse %(record Foo, bar : Int32 = 123, baz : String = "true")
 
       node.should be_a LC::Call
       node = node.as(LC::Call)
@@ -333,7 +333,7 @@ describe LC::Parser do
     end
 
     it "parses expressions ignoring semicolons" do
-      node = parse_expr %(;;;;;;;puts "hello world";;;;;;;)
+      node = parse %(;;;;;;;puts "hello world";;;;;;;)
 
       node.should be_a LC::Call
       node = node.as(LC::Call)

--- a/spec/parser/defs_spec.cr
+++ b/spec/parser/defs_spec.cr
@@ -3,7 +3,7 @@ require "../spec_helper"
 describe LC::Parser do
   context "defs", tags: %w[parser defs] do
     it "parses method defs" do
-      node = parse_stmt <<-CR
+      node = parse <<-CR
         def foo
         end
         CR
@@ -18,7 +18,7 @@ describe LC::Parser do
       node.return_type.should be_nil
       node.body.should be_empty
 
-      node = parse_stmt <<-CR
+      node = parse <<-CR
         def foo; end
         CR
 
@@ -34,7 +34,7 @@ describe LC::Parser do
     end
 
     it "parses method defs with a return type" do
-      node = parse_stmt <<-CR
+      node = parse <<-CR
         def foo() : Nil
         end
         CR
@@ -50,7 +50,7 @@ describe LC::Parser do
       node.return_type.as(LC::Const).value.should eq "Nil"
       node.body.should be_empty
 
-      node = parse_stmt <<-CR
+      node = parse <<-CR
         def foo : Nil; end
         CR
 
@@ -67,7 +67,7 @@ describe LC::Parser do
     end
 
     it "parses method defs with a body (1)" do
-      node = parse_stmt <<-CR
+      node = parse <<-CR
         def foo() : Nil
           puts "bar"
           puts "baz"
@@ -105,7 +105,7 @@ describe LC::Parser do
     end
 
     it "parses method defs with a body (2)" do
-      node = parse_stmt <<-CR
+      node = parse <<-CR
         def test : Nil
           foo
           bar
@@ -140,7 +140,7 @@ describe LC::Parser do
     end
 
     it "parses method defs with a single line body" do
-      node = parse_stmt "def foo() puts end"
+      node = parse "def foo() puts end"
       node.should be_a LC::Def
       node = node.as(LC::Def)
 
@@ -158,7 +158,7 @@ describe LC::Parser do
       expr.receiver.as(LC::Ident).value.should eq "puts"
       expr.args.should be_empty
 
-      node = parse_stmt %(def foo() puts "bar" end)
+      node = parse %(def foo() puts "bar" end)
       node.should be_a LC::Def
       node = node.as(LC::Def)
 
@@ -181,12 +181,12 @@ describe LC::Parser do
 
     it "disallows method def single line body without parentheses, newline or semicolon" do
       expect_raises(Exception, "expected a newline or semicolon after def signature") do
-        parse_stmt %(def foo puts "bar" end)
+        parse %(def foo puts "bar" end)
       end
     end
 
     it "parses method defs with a single parameter" do
-      node = parse_stmt <<-CR
+      node = parse <<-CR
         def greet(name : String = "dev") : Nil
           puts "Hello, ", name
         end
@@ -233,7 +233,7 @@ describe LC::Parser do
     end
 
     it "parses method defs with multiple parameters" do
-      node = parse_stmt <<-CR
+      node = parse <<-CR
         def add(a : Int32, b : Int32) : Int32
           a + b
         end
@@ -285,7 +285,7 @@ describe LC::Parser do
     end
 
     it "parses method defs with external parameter names" do
-      node = parse_stmt <<-CR
+      node = parse <<-CR
         def write(to file : IO) : Nil
         end
         CR
@@ -312,14 +312,14 @@ describe LC::Parser do
 
     it "disallows method def external names for block parameters" do
       expect_raises(Exception, "block parameters cannot have external names") do
-        parse_stmt <<-CR
+        parse <<-CR
           def write(&to file : IO ->) : Nil
           end
           CR
       end
 
       expect_raises(Exception, "block parameters cannot have external names") do
-        parse_stmt <<-CR
+        parse <<-CR
           def write(to &file : IO ->) : Nil
           end
           CR
@@ -327,7 +327,7 @@ describe LC::Parser do
     end
 
     it "parses method defs with free variables" do
-      node = parse_stmt <<-CR
+      node = parse <<-CR
         def foo(x : T, y : U) forall T, U
         end
         CR
@@ -359,7 +359,7 @@ describe LC::Parser do
     end
 
     it "parses abstract method defs" do
-      node = parse_stmt "abstract def read(slice : Bytes) : Int32"
+      node = parse "abstract def read(slice : Bytes) : Int32"
       node.should be_a LC::Def
       node = node.as(LC::Def)
 
@@ -384,7 +384,7 @@ describe LC::Parser do
     end
 
     it "parses private method defs" do
-      node = parse_stmt <<-CR
+      node = parse <<-CR
         private def read_impl(slice : Bytes) : Int32
           does_something_cool
         end
@@ -420,7 +420,7 @@ describe LC::Parser do
     end
 
     it "parses protected method defs" do
-      node = parse_stmt <<-CR
+      node = parse <<-CR
         protected def does_something_cool : Nil
         end
         CR
@@ -442,7 +442,7 @@ describe LC::Parser do
     end
 
     it "parses private abstract method defs" do
-      node = parse_stmt "private abstract def select_impl : Nil"
+      node = parse "private abstract def select_impl : Nil"
 
       node.should be_a LC::Def
       node = node.as(LC::Def)
@@ -461,7 +461,7 @@ describe LC::Parser do
     end
 
     it "parses protected abstract method defs" do
-      node = parse_stmt "protected abstract def execute : Bool"
+      node = parse "protected abstract def execute : Bool"
 
       node.should be_a LC::Def
       node = node.as(LC::Def)
@@ -481,21 +481,21 @@ describe LC::Parser do
 
     it "disallows duplicate visibility keywords on method defs" do
       expect_raises(Exception, "unexpected token 'private'") do
-        parse_stmt "private private def foo"
+        parse "private private def foo"
       end
 
       expect_raises(Exception, "unexpected token 'protected'") do
-        parse_stmt "protected protected def foo"
+        parse "protected protected def foo"
       end
 
       expect_raises(Exception, "unexpected token 'abstract'") do
-        parse_stmt "abstract abstract def foo"
+        parse "abstract abstract def foo"
       end
     end
 
     it "disallows private-protected keywords on method defs" do
       expect_raises(Exception, "cannot apply private and protected visibility") do
-        parse_stmt "private protected def foo"
+        parse "private protected def foo"
       end
     end
   end

--- a/spec/parser/infix_spec.cr
+++ b/spec/parser/infix_spec.cr
@@ -3,7 +3,7 @@ require "../spec_helper"
 describe LC::Parser do
   context "infix", tags: %w[parser infix] do
     it "parses infix operator expressions" do
-      node = parse_expr "1 + 1"
+      node = parse "1 + 1"
 
       node.should be_a LC::Infix
       node = node.as(LC::Infix)
@@ -15,7 +15,7 @@ describe LC::Parser do
       node.right.should be_a LC::IntLiteral
       node.right.as(LC::IntLiteral).value.should eq 1
 
-      node = parse_expr "false & true"
+      node = parse "false & true"
 
       node.should be_a LC::Infix
       node = node.as(LC::Infix)
@@ -29,7 +29,7 @@ describe LC::Parser do
     end
 
     it "parses grouped infix operator expressions" do
-      node = parse_expr "4 + (16 / 2)"
+      node = parse "4 + (16 / 2)"
 
       node.should be_a LC::Infix
       node = node.as(LC::Infix)
@@ -48,7 +48,7 @@ describe LC::Parser do
       expr.right.should be_a LC::IntLiteral
       expr.right.as(LC::IntLiteral).value.should eq 2
 
-      node = parse_expr "1 + (2 ** 3) - (20 // -4)"
+      node = parse "1 + (2 ** 3) - (20 // -4)"
 
       node.should be_a LC::Infix
       node = node.as(LC::Infix)
@@ -87,7 +87,7 @@ describe LC::Parser do
     end
 
     it "parses multiple ungrouped infix operator expressions" do
-      node = parse_expr "8 << 16 | 2 ^ 3"
+      node = parse "8 << 16 | 2 ^ 3"
 
       node.should be_a LC::Infix
       node = node.as(LC::Infix)
@@ -115,7 +115,7 @@ describe LC::Parser do
     end
 
     it "parses logic infix operator expressions" do
-      node = parse_expr "foo || bar && baz"
+      node = parse "foo || bar && baz"
       node.should be_a LC::Infix
       node = node.as(LC::Infix)
 

--- a/spec/parser/literals_spec.cr
+++ b/spec/parser/literals_spec.cr
@@ -42,12 +42,12 @@ describe LC::Parser do
 
     it "disallows calling underscore" do
       expect_raises(Exception, "underscore cannot be called as a method") do
-        parse_expr "_ foo"
+        parse "_ foo"
       end
     end
 
     it "parses empty proc expressions" do
-      {parse_expr("-> { }"), parse_expr("-> () { }")}.each do |node|
+      {parse("-> { }"), parse("-> () { }")}.each do |node|
         node.should be_a LC::ProcLiteral
         node = node.as(LC::ProcLiteral)
 
@@ -57,7 +57,7 @@ describe LC::Parser do
     end
 
     it "parses proc expressions with single arguments" do
-      node = parse_expr "-> (x : Int32) { }"
+      node = parse "-> (x : Int32) { }"
       node.should be_a LC::ProcLiteral
       node = node.as(LC::ProcLiteral)
 
@@ -73,7 +73,7 @@ describe LC::Parser do
     end
 
     it "parses proc expressions with multiple arguments" do
-      node = parse_expr "-> (a : Int32, b : Int32) { }"
+      node = parse "-> (a : Int32, b : Int32) { }"
       node.should be_a LC::ProcLiteral
       node = node.as(LC::ProcLiteral)
 
@@ -95,7 +95,7 @@ describe LC::Parser do
     end
 
     it "parses proc expressions with a body" do
-      node = parse_expr "-> do exit end"
+      node = parse "-> do exit end"
       node.should be_a LC::ProcLiteral
       node = node.as(LC::ProcLiteral)
 
@@ -112,7 +112,7 @@ describe LC::Parser do
     end
 
     it "parses multiline proc expressions" do
-      node = parse_expr <<-CR
+      node = parse <<-CR
         -> (
           a : Int32,
           b : Int32,

--- a/spec/parser/magic_spec.cr
+++ b/spec/parser/magic_spec.cr
@@ -3,7 +3,7 @@ require "../spec_helper"
 describe LC::Parser do
   context "magic vars" do
     it "parses magic line expressions" do
-      node = parse_expr <<-EXPR
+      node = parse <<-EXPR
 
 
       a = __LINE__
@@ -17,7 +17,7 @@ describe LC::Parser do
     end
 
     it "parses magic file expressions" do
-      node = parse_expr <<-EXPR, file: "my_file.cr"
+      node = parse <<-EXPR, file: "my_file.cr"
       a = __FILE__
       EXPR
 
@@ -29,7 +29,7 @@ describe LC::Parser do
     end
 
     it "parses magic dir expressions" do
-      node = parse_expr <<-EXPR, dir: "my_dir"
+      node = parse <<-EXPR, dir: "my_dir"
       a = __DIR__
       EXPR
 
@@ -41,14 +41,14 @@ describe LC::Parser do
     end
 
     pending "parses magic endline expressions" do
-      parse_expr <<-EXPR
+      parse <<-EXPR
         def my_func(a = __END_LINE__)
         end
         EXPR
     end
 
     pending "fails to parse endline not as a default param value" do
-      parse_expr <<-EXPR
+      parse <<-EXPR
         a = __END_LINE__
         EXPR
     end

--- a/spec/parser/prefix_spec.cr
+++ b/spec/parser/prefix_spec.cr
@@ -3,7 +3,7 @@ require "../spec_helper"
 describe LC::Parser do
   context "prefixes", tags: %w[parser prefix] do
     it "parses prefix operator expressions" do
-      node = parse_expr "!true"
+      node = parse "!true"
 
       node.should be_a LC::Prefix
       node = node.as(LC::Prefix)
@@ -14,7 +14,7 @@ describe LC::Parser do
     end
 
     it "parses double prefix operator expressions" do
-      node = parse_expr "!!false"
+      node = parse "!!false"
 
       node.should be_a LC::Prefix
       node = node.as(LC::Prefix)
@@ -29,7 +29,7 @@ describe LC::Parser do
     end
 
     it "parses prefix operator expressions in calls" do
-      node = parse_expr "puts !foo"
+      node = parse "puts !foo"
 
       node.should be_a LC::Call
       node = node.as(LC::Call)
@@ -49,7 +49,7 @@ describe LC::Parser do
 
     it "disallows prefix operators with incorrect syntax" do
       expect_raises(Exception) do
-        parse_expr "puts ! foo"
+        parse "puts ! foo"
       end
     end
   end

--- a/spec/parser/require_spec.cr
+++ b/spec/parser/require_spec.cr
@@ -3,7 +3,7 @@ require "../spec_helper"
 describe LC::Parser do
   context "requires" do
     it "parses require statements" do
-      node = parse_stmt %q(require "json")
+      node = parse %q(require "json")
       node.should be_a LC::Require
       node = node.as(LC::Require)
 

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -3,26 +3,13 @@ require "../src/compiler"
 
 alias LC = Lucid::Compiler
 
-def parse_expr(source : String, file : String = "STDIN", dir : String = "") : LC::Expression
+def parse(source : String, file : String = "STDIN", dir : String = "") : LC::Node
   tokens = LC::Lexer.run source, filename: file, dirname: dir
-  nodes = LC::Parser.parse tokens
-
-  nodes.size.should eq 1
-  nodes[0].should be_a LC::ExpressionStatement
-
-  nodes[0].as(LC::ExpressionStatement).value
-end
-
-def parse_stmt(source : String) : LC::Statement
-  tokens = LC::Lexer.run source
-  nodes = LC::Parser.parse tokens
-
-  nodes.size.should eq 1
-  nodes[0]
+  LC::Parser.parse(tokens)[0]
 end
 
 def assert_node(cls : LC::Node.class, for input : String) : Nil
-  parse_expr(input).class.should eq cls
+  parse(input).class.should eq cls
 end
 
 def assert_node_sequence(sequence : Array(LC::Node.class), for input : String) : Nil

--- a/src/compiler/node.cr
+++ b/src/compiler/node.cr
@@ -14,24 +14,18 @@ module Lucid::Compiler
     abstract def pretty_print(pp : PrettyPrint) : Nil
   end
 
-  abstract class Statement < Node
-  end
-
-  abstract class Expression < Node
-  end
-
-  class Def < Statement
+  class Def < Node
     property name : Node
     property params : Array(Parameter)
     property return_type : Node?
     property free_vars : Array(Const)
-    property body : Array(Expression)
+    property body : Array(Node)
     property? abstract : Bool = false
     property? private : Bool = false
     property? protected : Bool = false
 
     def initialize(@name : Node, @params : Array(Parameter), @return_type : Node?,
-                   @free_vars : Array(Const), @body : Array(Expression))
+                   @free_vars : Array(Const), @body : Array(Node))
       super()
     end
 
@@ -141,7 +135,7 @@ module Lucid::Compiler
     end
   end
 
-  class Require < Statement
+  class Require < Node
     property mod : Node
 
     def initialize(@mod : Node)
@@ -216,30 +210,7 @@ module Lucid::Compiler
     end
   end
 
-  class ExpressionStatement < Statement
-    property value : Expression
-
-    def initialize(@value : Expression)
-      super()
-    end
-
-    def to_s(io : IO) : Nil
-      io << '('
-      @value.to_s io
-      io << ')'
-    end
-
-    def pretty_print(pp : PrettyPrint) : Nil
-      pp.text "ExpressionStatement("
-      pp.group 1 do
-        pp.breakable ""
-        pp.nest { @value.pretty_print pp }
-      end
-      pp.text ")"
-    end
-  end
-
-  class Path < Expression
+  class Path < Node
     property names : Array(Ident)
     property? global : Bool
 
@@ -287,7 +258,7 @@ module Lucid::Compiler
     end
   end
 
-  class Ident < Expression
+  class Ident < Node
     property value : String
     property? global : Bool
 
@@ -340,7 +311,7 @@ module Lucid::Compiler
     end
   end
 
-  class Underscore < Expression
+  class Underscore < Node
     def to_s(io : IO) : Nil
       io << '_'
     end
@@ -350,7 +321,7 @@ module Lucid::Compiler
     end
   end
 
-  class Var < Expression
+  class Var < Node
     property name : Node
     property type : Node?
     property value : Node?
@@ -399,7 +370,7 @@ module Lucid::Compiler
   class ClassVar < Var
   end
 
-  class Prefix < Expression
+  class Prefix < Node
     enum Operator
       Not         # !
       BitAnd      # &
@@ -462,7 +433,7 @@ module Lucid::Compiler
     end
   end
 
-  class Infix < Expression
+  class Infix < Node
     enum Operator
       NotEqual       # !=
       PatternUnmatch # !~
@@ -596,7 +567,7 @@ module Lucid::Compiler
     end
   end
 
-  class Assign < Expression
+  class Assign < Node
     property target : Node
     property value : Node
 
@@ -623,7 +594,7 @@ module Lucid::Compiler
     end
   end
 
-  class Call < Expression
+  class Call < Node
     property receiver : Node
     property args : Array(Node)
 
@@ -664,7 +635,7 @@ module Lucid::Compiler
     end
   end
 
-  class StringLiteral < Expression
+  class StringLiteral < Node
     property value : String
 
     def initialize(@value : String)
@@ -682,7 +653,7 @@ module Lucid::Compiler
     end
   end
 
-  class IntLiteral < Expression
+  class IntLiteral < Node
     property value : Int64
 
     def initialize(@value : Int64)
@@ -700,7 +671,7 @@ module Lucid::Compiler
     end
   end
 
-  class FloatLiteral < Expression
+  class FloatLiteral < Node
     property value : Float64
 
     def initialize(@value : Float64)
@@ -718,7 +689,7 @@ module Lucid::Compiler
     end
   end
 
-  class BoolLiteral < Expression
+  class BoolLiteral < Node
     # ameba:disable Naming/QueryBoolMethods
     property value : Bool
 
@@ -737,7 +708,7 @@ module Lucid::Compiler
     end
   end
 
-  class NilLiteral < Expression
+  class NilLiteral < Node
     def to_s(io : IO) : Nil
       io << "nil"
     end
@@ -747,11 +718,11 @@ module Lucid::Compiler
     end
   end
 
-  class ProcLiteral < Expression
+  class ProcLiteral < Node
     property params : Array(Parameter)
-    property body : Array(Expression)
+    property body : Array(Node)
 
-    def initialize(@params : Array(Parameter), @body : Array(Expression))
+    def initialize(@params : Array(Parameter), @body : Array(Node))
       super()
     end
 


### PR DESCRIPTION
This PR removes the `Statement` and `Expression` parent node classes (including the interesting `ExpressionStatement` fusion) and flattens all node types to just `Node`. This will simplify parsing all of Crystal's structures in a mostly context-free way and removes the initial division of expressions and "statements".