### PR TITLE
Allow keywords as call names

### DIFF
--- a/spec/parser/calls_and_paths_spec.cr
+++ b/spec/parser/calls_and_paths_spec.cr
@@ -10,6 +10,21 @@ describe LC::Parser do
       call.args.size.should eq 0
     end
 
+    it "parses call expressions with keyword names" do
+      call = parse("::alias").should be_a LC::Call
+      ident = call.receiver.should be_a LC::Ident
+      ident.value.should eq "alias"
+      call.args.should be_empty
+
+      call = parse(%(::require("my_file.cr"))).should be_a LC::Call
+      ident = call.receiver.should be_a LC::Ident
+      ident.value.should eq "require"
+      call.args.size.should eq 1
+
+      str = call.args[0].should be_a LC::StringLiteral
+      str.value.should eq "my_file.cr"
+    end
+
     it "parses delimited call expressions" do
       {parse("puts;"), parse("puts\n")}.each do |node|
         call = node.should be_a LC::Call


### PR DESCRIPTION
This is a weird edge-case that only works if the call has a global/top-level receiver (`::`) or a type receiver (`self.` or Type.`).