### PR TITLE
Support class/instance variables

### DIFF
--- a/spec/parser/calls_and_paths_spec.cr
+++ b/spec/parser/calls_and_paths_spec.cr
@@ -33,6 +33,20 @@ describe LC::Parser do
       end
     end
 
+    it "parses instance variables" do
+      call = parse("@foo").should be_a LC::Call
+      ivar = call.receiver.should be_a LC::InstanceVar
+      ivar.value.should eq "foo"
+      call.args.should be_empty
+    end
+
+    it "parses class variables" do
+      call = parse("@@bar").should be_a LC::Call
+      cvar = call.receiver.should be_a LC::ClassVar
+      cvar.value.should eq "bar"
+      call.args.should be_empty
+    end
+
     it "parses path call expressions" do
       call = parse("foo.bar.baz").should be_a LC::Call
       path = call.receiver.should be_a LC::Path

--- a/src/compiler/lexer.cr
+++ b/src/compiler/lexer.cr
@@ -51,6 +51,21 @@ module Lucid::Compiler
         Token.new :newline, loc
       when '#'
         lex_comment
+      when '@'
+        start = current_pos + 1
+        kind = Token::Kind::InstanceVar
+
+        if next_char == '@'
+          kind = Token::Kind::ClassVar
+          start += 1
+          next_char
+        end
+
+        while current_char.ascii_alphanumeric? || current_char == '_'
+          next_char
+        end
+
+        Token.new kind, location, read_string_from start
       when '('
         next_char
         Token.new :left_paren, location

--- a/src/compiler/lexer.cr
+++ b/src/compiler/lexer.cr
@@ -539,6 +539,10 @@ module Lucid::Compiler
       @reader.next_char
     end
 
+    private def peek_char : Char
+      @reader.peek_next_char
+    end
+
     private def next_sequence?(*chars : Char) : Bool
       chars.all? { |c| next_char == c }
     end
@@ -579,7 +583,7 @@ module Lucid::Compiler
           next_char
           break
         when '!', '='
-          next_char unless @reader.peek_next_char == '='
+          next_char unless peek_char == '='
           break
         else
           break
@@ -590,7 +594,7 @@ module Lucid::Compiler
     end
 
     private def lex_keyword_or_ident(keyword : Token::Kind, start : Int32 = current_pos) : Token
-      char = @reader.peek_next_char
+      char = peek_char
 
       if char.ascii_alphanumeric? || char.in?('_', '!', '?', '=')
         lex_ident start
@@ -690,7 +694,7 @@ module Lucid::Compiler
           kind = Token::Kind::Float
           case next_char
           when '3'
-            if next_char == '2' && !@reader.peek_next_char.ascii_number?
+            if next_char == '2' && !peek_char.ascii_number?
               next_char
             else
               kind = Token::Kind::FloatBadSuffix
@@ -700,7 +704,7 @@ module Lucid::Compiler
             end
             break
           when '6'
-            if next_char == '4' && !@reader.peek_next_char.ascii_number?
+            if next_char == '4' && !peek_char.ascii_number?
               next_char
             else
               kind = Token::Kind::FloatBadSuffix
@@ -719,7 +723,7 @@ module Lucid::Compiler
         when 'i', 'u'
           case next_char
           when '8'
-            if @reader.peek_next_char.ascii_number?
+            if peek_char.ascii_number?
               kind = Token::Kind::IntegerBadSuffix
               while next_char.ascii_number?
                 # skip
@@ -731,7 +735,7 @@ module Lucid::Compiler
           when '1'
             case next_char
             when '2'
-              if next_char == '8' && !@reader.peek_next_char.ascii_number?
+              if next_char == '8' && !peek_char.ascii_number?
                 next_char
               else
                 kind = Token::Kind::IntegerBadSuffix
@@ -741,7 +745,7 @@ module Lucid::Compiler
               end
               break
             when '6'
-              if @reader.peek_next_char.ascii_number?
+              if peek_char.ascii_number?
                 kind = Token::Kind::IntegerBadSuffix
                 while next_char.ascii_number?
                   # skip
@@ -758,7 +762,7 @@ module Lucid::Compiler
               break
             end
           when '3'
-            if next_char == '2' && !@reader.peek_next_char.ascii_number?
+            if next_char == '2' && !peek_char.ascii_number?
               next_char
             else
               kind = Token::Kind::IntegerBadSuffix
@@ -768,7 +772,7 @@ module Lucid::Compiler
             end
             break
           when '6'
-            if next_char == '4' && !@reader.peek_next_char.ascii_number?
+            if next_char == '4' && !peek_char.ascii_number?
               next_char
             else
               kind = Token::Kind::IntegerBadSuffix
@@ -788,7 +792,7 @@ module Lucid::Compiler
           next
         when '.'
           break if kind.float?
-          case @reader.peek_next_char
+          case peek_char
           when .ascii_letter?, '.'
             suffix = false
             break
@@ -831,7 +835,7 @@ module Lucid::Compiler
     end
 
     private def read_unicode_escape(allow_spaces : Bool) : Char
-      if @reader.peek_next_char == '{'
+      if peek_char == '{'
         next_char
         codepoint = 0
         found_brace = found_space = found_digit = false

--- a/src/compiler/node.cr
+++ b/src/compiler/node.cr
@@ -327,7 +327,7 @@ module Lucid::Compiler
     end
   end
 
-  class Ident < Node
+  abstract class Identifiable < Node
     property value : String
     property? global : Bool
 
@@ -340,7 +340,7 @@ module Lucid::Compiler
     end
 
     def pretty_print(pp : PrettyPrint) : Nil
-      pp.text "Ident("
+      pp.text "#{self.class.name}("
       pp.group 1 do
         pp.breakable ""
         pp.text "value: "
@@ -354,23 +354,17 @@ module Lucid::Compiler
     end
   end
 
-  class Const < Ident
-    def pretty_print(pp : PrettyPrint) : Nil
-      pp.text "Const("
-      pp.group 1 do
-        pp.breakable ""
-        pp.text "value: "
-        pp.text @value.inspect
-        pp.comma
-
-        pp.text "global: "
-        pp.text @global
-      end
-      pp.text ")"
-    end
+  class Ident < Identifiable
   end
 
-  class Self < Ident
+  class Const < Identifiable
+  end
+
+  class Self < Identifiable
+    def initialize(@global : Bool)
+      super "self", global
+    end
+
     def to_s(io : IO) : Nil
       io << "self"
     end
@@ -380,7 +374,11 @@ module Lucid::Compiler
     end
   end
 
-  class Underscore < Node
+  class Underscore < Identifiable
+    def initialize
+      super "_", false
+    end
+
     def to_s(io : IO) : Nil
       io << '_'
     end
@@ -388,6 +386,12 @@ module Lucid::Compiler
     def pretty_print(pp : PrettyPrint) : Nil
       pp.text "Underscore"
     end
+  end
+
+  class InstanceVar < Identifiable
+  end
+
+  class ClassVar < Identifiable
   end
 
   class Var < Node
@@ -431,12 +435,6 @@ module Lucid::Compiler
       end
       pp.text ")"
     end
-  end
-
-  class InstanceVar < Var
-  end
-
-  class ClassVar < Var
   end
 
   class Prefix < Node

--- a/src/compiler/parser.cr
+++ b/src/compiler/parser.cr
@@ -517,10 +517,10 @@ module Lucid::Compiler
           case node = parse_var_or_call next_token_skip(space: true), false
           when Assign
             Var.new(receiver, node.target, node.value).at(receiver.loc & node.loc)
-          when Ident
+          when Ident, Const
             Var.new(receiver, node, nil).at(receiver.loc & node.loc)
           else
-            raise "BUG: expected Assign or Ident; got #{node.class}"
+            raise "BUG: expected Assign, Ident or Const; got #{node.class}"
           end
         when .assign?
           node = parse_expression next_token_skip(space: true), :lowest
@@ -544,7 +544,7 @@ module Lucid::Compiler
 
       case token.kind
       when .self?
-        names << Self.new("self", global).at(token.loc)
+        names << Self.new(global).at(token.loc)
       when .ident?
         names << Ident.new(token.str_value, global).at(token.loc)
       when Token::Kind::Abstract..Token::Kind::Require
@@ -559,7 +559,7 @@ module Lucid::Compiler
 
         case token.kind
         when .self?
-          names << Self.new("self", false).at(token.loc)
+          names << Self.new(false).at(token.loc)
         when .ident?
           names << Ident.new(token.str_value, false).at(token.loc)
         when Token::Kind::Abstract..Token::Kind::Require
@@ -597,7 +597,7 @@ module Lucid::Compiler
         case token.kind
         when .self?
           in_method = true
-          names << Self.new("self", global).at(token.loc)
+          names << Self.new(global).at(token.loc)
         when .ident?
           in_method = true
           names << Ident.new(token.str_value, global).at(token.loc)

--- a/src/compiler/token.cr
+++ b/src/compiler/token.cr
@@ -8,6 +8,8 @@ module Lucid::Compiler
 
       Ident
       Const
+      InstanceVar
+      ClassVar
 
       String
       Char


### PR DESCRIPTION
Identifiable types are now also scoped under an `Identifiable` base class which should make handing paths a lot easier.