### PR TITLE
Implement namespace types

### DIFF
--- a/spec/lexer_spec.cr
+++ b/spec/lexer_spec.cr
@@ -298,6 +298,16 @@ describe LC::Lexer, tags: "lexer" do
     )
   end
 
+  it "parses include/extend expressions" do
+    assert_tokens(
+      <<-CR,
+        include Base
+        extend self
+        CR
+      :include, :space, :const, :newline, :extend, :space, :self, :eof
+    )
+  end
+
   it "parses enum expressions" do
     assert_tokens(
       <<-CR,

--- a/spec/parser/namespace_spec.cr
+++ b/spec/parser/namespace_spec.cr
@@ -1,0 +1,68 @@
+require "../spec_helper"
+
+describe LC::Parser do
+  context "namespace", tags: %w[parser namespace] do
+    it "parses module defs" do
+      {"module Foo\nend", "module Foo; end", "module Foo end"}.each do |code|
+        mod = parse(code).should be_a LC::ModuleDef
+        const = mod.name.should be_a LC::Const
+        const.value.should eq "Foo"
+      end
+    end
+
+    it "parses nested module defs" do
+      mod = parse(<<-CR).should be_a LC::ModuleDef
+        module Foo
+          module Bar
+          end
+        end
+        CR
+
+      const = mod.name.should be_a LC::Const
+      const.value.should eq "Foo"
+      mod.types.size.should eq 1
+
+      mod = mod.types[0].should be_a LC::ModuleDef
+      const = mod.name.should be_a LC::Const
+      const.value.should eq "Bar"
+    end
+
+    it "parses types inside namespaces" do
+      mod = parse(<<-CR).should be_a LC::ModuleDef
+        module Foo
+          module Bar
+            def baz : Nil
+            end
+          end
+
+          alias Qux = Bar
+        end
+        CR
+
+      const = mod.name.should be_a LC::Const
+      const.value.should eq "Foo"
+      mod.aliases.size.should eq 1
+
+      aliased = mod.aliases[0].should be_a LC::Alias
+      const = aliased.name.should be_a LC::Const
+      const.value.should eq "Qux"
+
+      const = aliased.type.should be_a LC::Const
+      const.value.should eq "Bar"
+      mod.types.size.should eq 1
+
+      mod = mod.types[0].should be_a LC::ModuleDef
+      const = mod.name.should be_a LC::Const
+      const.value.should eq "Bar"
+      mod.methods.size.should eq 1
+
+      method = mod.methods[0]
+      ident = method.name.should be_a LC::Ident
+      ident.value.should eq "baz"
+
+      const = method.return_type.should be_a LC::Const
+      const.value.should eq "Nil"
+      method.body.should be_empty
+    end
+  end
+end

--- a/spec/parser/namespace_spec.cr
+++ b/spec/parser/namespace_spec.cr
@@ -53,9 +53,13 @@ describe LC::Parser do
       mod = parse(<<-CR).should be_a LC::ModuleDef
         module Foo
           module Bar
+            extend self
+
             def baz : Nil
             end
           end
+
+          include Qux
 
           alias Qux = Bar
         end
@@ -63,6 +67,10 @@ describe LC::Parser do
 
       const = mod.name.should be_a LC::Const
       const.value.should eq "Foo"
+      mod.includes.size.should eq 1
+
+      const = mod.includes[0].type.should be_a LC::Const
+      const.value.should eq "Qux"
       mod.aliases.size.should eq 1
 
       aliased = mod.aliases[0].should be_a LC::Alias
@@ -76,6 +84,11 @@ describe LC::Parser do
       mod = mod.types[0].should be_a LC::ModuleDef
       const = mod.name.should be_a LC::Const
       const.value.should eq "Bar"
+      mod.extends.size.should eq 1
+
+      call = mod.extends[0].type.should be_a LC::Call
+      call.receiver.should be_a LC::Self
+      call.args.should be_empty
       mod.methods.size.should eq 1
 
       method = mod.methods[0]

--- a/spec/parser/namespace_spec.cr
+++ b/spec/parser/namespace_spec.cr
@@ -52,7 +52,7 @@ describe LC::Parser do
     it "parses types inside namespaces" do
       mod = parse(<<-CR).should be_a LC::ModuleDef
         module Foo
-          module Bar
+          class Bar < Baz
             extend self
 
             def baz : Nil
@@ -81,17 +81,20 @@ describe LC::Parser do
       const.value.should eq "Bar"
       mod.types.size.should eq 1
 
-      mod = mod.types[0].should be_a LC::ModuleDef
-      const = mod.name.should be_a LC::Const
+      cls = mod.types[0].should be_a LC::ClassDef
+      const = cls.name.should be_a LC::Const
       const.value.should eq "Bar"
-      mod.extends.size.should eq 1
 
-      call = mod.extends[0].type.should be_a LC::Call
+      const = cls.superclass.should be_a LC::Const
+      const.value.should eq "Baz"
+      cls.extends.size.should eq 1
+
+      call = cls.extends[0].type.should be_a LC::Call
       call.receiver.should be_a LC::Self
       call.args.should be_empty
-      mod.methods.size.should eq 1
+      cls.methods.size.should eq 1
 
-      method = mod.methods[0]
+      method = cls.methods[0]
       ident = method.name.should be_a LC::Ident
       ident.value.should eq "baz"
 

--- a/spec/parser/namespace_spec.cr
+++ b/spec/parser/namespace_spec.cr
@@ -2,6 +2,28 @@ require "../spec_helper"
 
 describe LC::Parser do
   context "namespace", tags: %w[parser namespace] do
+    it "parses valid include/extend expressions" do
+      includer = parse("include Base").should be_a LC::Include
+      const = includer.type.should be_a LC::Const
+      const.value.should eq "Base"
+
+      extender = parse("extend self").should be_a LC::Extend
+      call = extender.type.should be_a LC::Call
+
+      call.receiver.should be_a LC::Self
+      call.args.should be_empty
+    end
+
+    it "parses invalid include/extend expressions" do
+      includer = parse("include").should be_a LC::Include
+      error = includer.type.should be_a LC::Error
+      token = error.target.should be_a LC::Token
+
+      token.kind.eof?.should be_true
+      token.raw_value.should be_nil
+      error.message.should eq "unexpected end of file"
+    end
+
     it "parses module defs" do
       {"module Foo\nend", "module Foo; end", "module Foo end"}.each do |code|
         mod = parse(code).should be_a LC::ModuleDef

--- a/src/compiler/lexer.cr
+++ b/src/compiler/lexer.cr
@@ -423,7 +423,8 @@ module Lucid::Compiler
         end
       when 'e'
         start = current_pos
-        if next_char == 'n'
+        case next_char
+        when 'n'
           case next_char
           when 'd'
             lex_keyword_or_ident :end, start
@@ -433,6 +434,12 @@ module Lucid::Compiler
             else
               lex_ident start
             end
+          else
+            lex_ident start
+          end
+        when 'x'
+          if next_sequence?('t', 'e', 'n', 'd')
+            lex_keyword_or_ident :extend, start
           else
             lex_ident start
           end
@@ -459,8 +466,19 @@ module Lucid::Compiler
         end
       when 'i'
         start = current_pos
-        if next_sequence?('s', '_', 'a', '?')
-          lex_keyword_or_ident :is_a, start
+        case next_char
+        when 'n'
+          if next_sequence?('c', 'l', 'u', 'd', 'e')
+            lex_keyword_or_ident :include, start
+          else
+            lex_ident start
+          end
+        when 's'
+          if next_sequence?('_', 'a', '?')
+            lex_keyword_or_ident :is_a, start
+          else
+            lex_ident start
+          end
         else
           lex_ident start
         end

--- a/src/compiler/node.cr
+++ b/src/compiler/node.cr
@@ -54,6 +54,232 @@ module Lucid::Compiler
     end
   end
 
+  abstract class NamespaceDef < Node
+    property name : Node
+    property free_vars : Array(Node)
+    property superclass : Node?
+    property? private : Bool
+    property includes : Array(Node)
+    property extends : Array(Node)
+    property constants : Array(Node)
+    property aliases : Array(Alias)
+    # property annotations : Array(Annotation)
+    property types : Array(Node) # modules, classes, structs, enums
+    property methods : Array(Def)
+    property body : Array(Node) # for calls, errors & dead code
+
+    def initialize(@name : Node, @free_vars : Array(Node), @superclass : Node?, @private : Bool,
+                   @includes : Array(Node), @extends : Array(Node), @constants : Array(Node),
+                   @aliases : Array(Node), @types : Array(Node), @methods : Array(Def),
+                   @body : Array(Node))
+      super()
+    end
+
+    def to_s(io : IO) : Nil
+      @name.to_s io
+
+      unless @free_vars.empty?
+        io << '('
+        @free_vars[0].to_s io
+
+        if @free_vars.size > 1
+          @free_vars.skip(1).each do |var|
+            io << ", "
+            var.to_s io
+          end
+        end
+
+        io << ')'
+      end
+
+      if cls = @superclass
+        io << " < "
+        cls.to_s io
+      end
+
+      io << '\n'
+      unless @includes.empty?
+        @includes.each do |type|
+          io << "include "
+          type.to_s io
+          io << '\n'
+        end
+      end
+
+      io << '\n'
+      unless @extends.empty?
+        @extends.each do |type|
+          io << "extend "
+          type.to_s io
+          io << '\n'
+        end
+      end
+
+      io << '\n'
+      unless @constants.empty?
+        @constants.each do |const|
+          const.to_s io
+          io << '\n'
+        end
+      end
+
+      io << '\n'
+      unless @aliases.empty?
+        @aliases.each do |type|
+          type.to_s io
+          io << '\n'
+        end
+      end
+
+      io << '\n'
+      unless @types.empty?
+        @types.each do |type|
+          type.to_s io
+          io << '\n'
+        end
+      end
+
+      io << '\n'
+      unless @methods.empty?
+        @methods.each do |method|
+          method.to_s io
+          io << '\n'
+        end
+      end
+
+      io << "\nend"
+    end
+
+    def pretty_print(pp : PrettyPrint) : Nil
+      pp.group 1 do
+        pp.breakable ""
+        pp.text "name: "
+        @name.pretty_print pp
+        pp.comma
+
+        pp.text "free_vars: "
+        @free_vars.pretty_print pp
+        pp.comma
+
+        pp.text "superclass: "
+        @superclass.pretty_print pp
+        pp.comma
+
+        pp.text "private: "
+        @private.pretty_print pp
+        pp.comma
+
+        pp.text "includes: ["
+        pp.group 1 do
+          pp.breakable ""
+          next if @includes.empty?
+
+          @includes[0].pretty_print pp
+          if @includes.size > 1
+            @includes.skip(1).each do |type|
+              pp.comma
+              type.pretty_print pp
+            end
+          end
+        end
+        pp.text "]"
+        pp.comma
+
+        pp.text "extends: ["
+        pp.group 1 do
+          pp.breakable ""
+          next if @extends.empty?
+
+          @extends[0].pretty_print pp
+          if @extends.size > 1
+            @extends.skip(1).each do |type|
+              pp.comma
+              type.pretty_print pp
+            end
+          end
+        end
+        pp.text "]"
+        pp.comma
+
+        pp.text "constants: ["
+        pp.group 1 do
+          pp.breakable ""
+          next if @constants.empty?
+
+          @constants[0].pretty_print pp
+          if @constants.size > 1
+            @constants.skip(1).each do |type|
+              pp.comma
+              type.pretty_print pp
+            end
+          end
+        end
+        pp.text "]"
+        pp.comma
+
+        pp.text "aliases: ["
+        pp.group 1 do
+          pp.breakable ""
+          next if @aliases.empty?
+
+          @aliases[0].pretty_print pp
+          if @aliases.size > 1
+            @aliases.skip(1).each do |type|
+              pp.comma
+              type.pretty_print pp
+            end
+          end
+        end
+        pp.text "]"
+        pp.comma
+
+        pp.text "types: ["
+        pp.group 1 do
+          pp.breakable ""
+          next if @types.empty?
+
+          @types[0].pretty_print pp
+          if @types.size > 1
+            @types.skip(1).each do |type|
+              pp.comma
+              type.pretty_print pp
+            end
+          end
+        end
+        pp.text "]"
+        pp.comma
+
+        pp.text "methods: ["
+        pp.group 1 do
+          pp.breakable ""
+          next if @methods.empty?
+
+          @methods[0].pretty_print pp
+          if @methods.size > 1
+            @methods.skip(1).each do |method|
+              pp.comma
+              method.pretty_print pp
+            end
+          end
+        end
+        pp.text "]"
+      end
+    end
+  end
+
+  class ModuleDef < NamespaceDef
+    def to_s(io : IO) : Nil
+      io << "private " if @private
+      super
+    end
+
+    def pretty_print(pp : PrettyPrint) : Nil
+      pp.text "ModuleDef("
+      super
+      pp.text ")"
+    end
+  end
+
   class Def < Node
     property name : Node
     property params : Array(Parameter)

--- a/src/compiler/node.cr
+++ b/src/compiler/node.cr
@@ -281,6 +281,38 @@ module Lucid::Compiler
     end
   end
 
+  class ClassDef < NamespaceDef
+    property? abstract : Bool = false
+
+    def to_s(io : IO) : Nil
+      io << "private " if @private
+      io << "abstract " if @abstract
+      super
+    end
+
+    def pretty_print(pp : PrettyPrint) : Nil
+      pp.text "ClassDef("
+      super
+      pp.text ")"
+    end
+  end
+
+  class StructDef < NamespaceDef
+    property? abstract : Bool = false
+
+    def to_s(io : IO) : Nil
+      io << "private " if @private
+      io << "abstract " if @abstract
+      super
+    end
+
+    def pretty_print(pp : PrettyPrint) : Nil
+      pp.text "StructDef("
+      super
+      pp.text ")"
+    end
+  end
+
   class Def < Node
     property name : Node
     property params : Array(Parameter)

--- a/src/compiler/node.cr
+++ b/src/compiler/node.cr
@@ -401,6 +401,52 @@ module Lucid::Compiler
     end
   end
 
+  class Include < Node
+    property type : Node
+
+    def initialize(@type : Node)
+      super()
+    end
+
+    def to_s(io : IO) : Nil
+      io << "include "
+      @type.to_s io
+    end
+
+    def pretty_print(pp : PrettyPrint) : Nil
+      pp.text "Include("
+      pp.group 1 do
+        pp.breakable ""
+        pp.text "type: "
+        @type.pretty_print pp
+      end
+      pp.text ")"
+    end
+  end
+
+  class Extend < Node
+    property type : Node
+
+    def initialize(@type : Node)
+      super()
+    end
+
+    def to_s(io : IO) : Nil
+      io << "extend "
+      @type.to_s io
+    end
+
+    def pretty_print(pp : PrettyPrint) : Nil
+      pp.text "Extend("
+      pp.group 1 do
+        pp.breakable ""
+        pp.text "type: "
+        @type.pretty_print pp
+      end
+      pp.text ")"
+    end
+  end
+
   class Alias < Node
     property name : Node
     property type : Node

--- a/src/compiler/node.cr
+++ b/src/compiler/node.cr
@@ -59,8 +59,8 @@ module Lucid::Compiler
     property free_vars : Array(Node)
     property superclass : Node?
     property? private : Bool
-    property includes : Array(Node)
-    property extends : Array(Node)
+    property includes : Array(Include)
+    property extends : Array(Extend)
     property constants : Array(Node)
     property aliases : Array(Alias)
     # property annotations : Array(Annotation)
@@ -69,8 +69,8 @@ module Lucid::Compiler
     property body : Array(Node) # for calls, errors & dead code
 
     def initialize(@name : Node, *, @free_vars : Array(Node) = [] of Node, @superclass : Node? = nil,
-                   @private : Bool = false, @includes : Array(Node) = [] of Node,
-                   @extends : Array(Node) = [] of Node, @constants : Array(Node) = [] of Node,
+                   @private : Bool = false, @includes : Array(Include) = [] of Include,
+                   @extends : Array(Extend) = [] of Extend, @constants : Array(Node) = [] of Node,
                    @aliases : Array(Alias) = [] of Alias, @types : Array(Node) = [] of Node,
                    @methods : Array(Def) = [] of Def, @body : Array(Node) = [] of Node)
       super()

--- a/src/compiler/node.cr
+++ b/src/compiler/node.cr
@@ -68,10 +68,11 @@ module Lucid::Compiler
     property methods : Array(Def)
     property body : Array(Node) # for calls, errors & dead code
 
-    def initialize(@name : Node, @free_vars : Array(Node), @superclass : Node?, @private : Bool,
-                   @includes : Array(Node), @extends : Array(Node), @constants : Array(Node),
-                   @aliases : Array(Node), @types : Array(Node), @methods : Array(Def),
-                   @body : Array(Node))
+    def initialize(@name : Node, *, @free_vars : Array(Node) = [] of Node, @superclass : Node? = nil,
+                   @private : Bool = false, @includes : Array(Node) = [] of Node,
+                   @extends : Array(Node) = [] of Node, @constants : Array(Node) = [] of Node,
+                   @aliases : Array(Alias) = [] of Alias, @types : Array(Node) = [] of Node,
+                   @methods : Array(Def) = [] of Def, @body : Array(Node) = [] of Node)
       super()
     end
 

--- a/src/compiler/parser.cr
+++ b/src/compiler/parser.cr
@@ -220,10 +220,7 @@ module Lucid::Compiler
       start = token.loc
       name = parse_const_or_path next_token_skip(space: true), false
       token = next_token_skip space: true, newline: true, semicolon: true
-      aliases = [] of Alias
-      types = [] of Node
-      methods = [] of Def
-      body = [] of Node
+      mod = ModuleDef.new name
 
       loop do
         break if token.kind.end?
@@ -231,29 +228,26 @@ module Lucid::Compiler
 
         case node = parse token
         when Alias
-          aliases << node
+          mod.aliases << node
         when ModuleDef
-          types << node
+          mod.types << node
         when Def
-          methods << node
+          mod.methods << node
         when Nil
-          body << raise current_token, "unexpected end of file"
+          mod.body << raise current_token, "unexpected end of file"
           break
         else
-          body << node
+          mod.body << node
         end
 
         break if current_token.kind.end?
         token = next_token_skip space: true, newline: true, semicolon: true
       end
 
+      mod.at(start & current_token.loc)
       skip_token
 
-      ModuleDef.new(
-        name, [] of Node, nil, false,
-        [] of Node, [] of Node, [] of Node,
-        aliases, types, methods, body
-      ).at(start & token.loc)
+      mod
     end
 
     # DEF ::=

--- a/src/compiler/parser.cr
+++ b/src/compiler/parser.cr
@@ -157,6 +157,8 @@ module Lucid::Compiler
         parse_module token
       when .def?
         parse_def token
+      when .include?, .extend?
+        parse_include_or_extend token
       when .alias?
         parse_alias token
       when .require?
@@ -386,6 +388,22 @@ module Lucid::Compiler
 
       skip_token
       Def.new(name, params, return_type, free_vars, body).at(start & token.loc)
+    end
+
+    private def parse_include_or_extend(start : Token) : Node
+      token = next_token_skip space: true
+
+      if token.kind.eof?
+        node = raise token, "unexpected end of file"
+      else
+        node = parse(token).not_nil!
+      end
+
+      if start.kind.include?
+        Include.new node
+      else
+        Extend.new node
+      end
     end
 
     private def parse_alias(token : Token) : Node

--- a/src/compiler/token.cr
+++ b/src/compiler/token.cr
@@ -95,7 +95,9 @@ module Lucid::Compiler
       Do
       End
       Enum
+      Extend
       Forall
+      Include
       IsA
       # Lib
       Module


### PR DESCRIPTION
Closes #24 and resolves part of #23. Binding-specific parsing of structs will come with the `lib` implementation.