### PR TITLE
Implement `TypeModifier`

### DIFF
--- a/spec/parser/defs_spec.cr
+++ b/spec/parser/defs_spec.cr
@@ -503,80 +503,60 @@ describe LC::Parser do
       node.abstract?.should be_true
     end
 
-    pending "errors on duplicate visibility keywords on method defs" do
-      nodes = parse_all "private private def foo; end"
-      nodes.size.should eq 2
+    it "errors on duplicate visibility keywords on method defs" do
+      mod = parse("private private def foo; end").should be_a LC::TypeModifier
+      mod.kind.private?.should be_true
 
-      error = nodes[0].should be_a LC::Error
-      token = error.target.should be_a LC::Token
+      error = mod.expr.should be_a LC::Error
+      error.message.should eq "cannot apply private to private"
 
-      token.kind.private?.should be_true
-      token.raw_value.should be_nil
-      error.message.should eq "unexpected token 'private'"
+      mod = error.target.should be_a LC::TypeModifier
+      mod.kind.private?.should be_true
 
-      method = nodes[1].should be_a LC::Def
-      ident = method.name.should be_a LC::Ident
+      node = mod.expr.should be_a LC::Def
+      ident = node.name.should be_a LC::Ident
       ident.value.should eq "foo"
 
-      method.private?.should be_true
-      method.protected?.should be_false
-      method.abstract?.should be_false
+      mod = parse("protected protected def bar; end").should be_a LC::TypeModifier
+      mod.kind.protected?.should be_true
 
-      nodes = parse_all "protected protected def bar; end"
-      nodes.size.should eq 2
+      error = mod.expr.should be_a LC::Error
+      error.message.should eq "cannot apply protected to protected"
 
-      error = nodes[0].should be_a LC::Error
-      token = error.target.should be_a LC::Token
+      mod = error.target.should be_a LC::TypeModifier
+      mod.kind.protected?.should be_true
 
-      token.kind.protected?.should be_true
-      token.raw_value.should be_nil
-      error.message.should eq "unexpected token 'protected'"
-
-      method = nodes[1].should be_a LC::Def
-      ident = method.name.should be_a LC::Ident
+      node = mod.expr.should be_a LC::Def
+      ident = node.name.should be_a LC::Ident
       ident.value.should eq "bar"
 
-      method.private?.should be_false
-      method.protected?.should be_true
-      method.abstract?.should be_false
+      mod = parse("abstract abstract def baz").should be_a LC::TypeModifier
+      mod.kind.abstract?.should be_true
 
-      nodes = parse_all "abstract abstract def baz"
-      nodes.size.should eq 2
+      error = mod.expr.should be_a LC::Error
+      error.message.should eq "cannot apply abstract to abstract"
 
-      error = nodes[0].should be_a LC::Error
-      token = error.target.should be_a LC::Token
+      mod = error.target.should be_a LC::TypeModifier
+      mod.kind.abstract?.should be_true
 
-      token.kind.abstract?.should be_true
-      token.raw_value.should be_nil
-      error.message.should eq "unexpected token 'abstract'"
-
-      method = nodes[1].should be_a LC::Def
-      ident = method.name.should be_a LC::Ident
+      node = mod.expr.should be_a LC::Def
+      ident = node.name.should be_a LC::Ident
       ident.value.should eq "baz"
-
-      method.private?.should be_false
-      method.protected?.should be_false
-      method.abstract?.should be_true
     end
 
-    pending "errors on private-protected keywords on method defs" do
-      nodes = parse_all "private protected def foo; end"
-      nodes.size.should eq 2
+    it "errors on private-protected keywords on method defs" do
+      mod = parse("private protected def foo; end").should be_a LC::TypeModifier
+      mod.kind.private?.should be_true
 
-      error = nodes[0].should be_a LC::Error
-      token = error.target.should be_a LC::Token
+      error = mod.expr.should be_a LC::Error
+      error.message.should eq "cannot apply private to protected"
 
-      token.kind.protected?.should be_true
-      token.raw_value.should be_nil
-      error.message.should eq "cannot apply private and protected visibility"
+      mod = error.target.should be_a LC::TypeModifier
+      mod.kind.protected?.should be_true
 
-      method = nodes[1].should be_a LC::Def
-      ident = method.name.should be_a LC::Ident
+      node = mod.expr.should be_a LC::Def
+      ident = node.name.should be_a LC::Ident
       ident.value.should eq "foo"
-
-      method.private?.should be_false
-      method.protected?.should be_true
-      method.abstract?.should be_false
     end
   end
 end

--- a/spec/parser/defs_spec.cr
+++ b/spec/parser/defs_spec.cr
@@ -397,6 +397,7 @@ describe LC::Parser do
     it "parses abstract method defs" do
       mod = parse("abstract def read(slice : Bytes) : Int32").should be_a LC::TypeModifier
       mod.kind.abstract?.should be_true
+      mod.loc.to_tuple.should eq({0, 0, 0, 8})
 
       node = mod.expr.should be_a LC::Def
       ident = node.name.should be_a LC::Ident
@@ -425,6 +426,7 @@ describe LC::Parser do
         CR
 
       mod.kind.private?.should be_true
+      mod.loc.to_tuple.should eq({0, 0, 0, 7})
 
       node = mod.expr.should be_a LC::Def
       ident = node.name.should be_a LC::Ident
@@ -454,6 +456,7 @@ describe LC::Parser do
         CR
 
       mod.kind.protected?.should be_true
+      mod.loc.to_tuple.should eq({0, 0, 0, 9})
 
       node = mod.expr.should be_a LC::Def
       ident = node.name.should be_a LC::Ident
@@ -468,6 +471,7 @@ describe LC::Parser do
     it "parses private abstract method defs" do
       mod = parse("private abstract def select_impl : Nil").should be_a LC::TypeModifier
       mod.kind.private?.should be_true
+      mod.loc.to_tuple.should eq({0, 0, 0, 7})
 
       mod = mod.expr.should be_a LC::TypeModifier
       mod.kind.abstract?.should be_true
@@ -487,6 +491,7 @@ describe LC::Parser do
     it "parses protected abstract method defs" do
       mod = parse("protected abstract def execute : Bool").should be_a LC::TypeModifier
       mod.kind.protected?.should be_true
+      mod.loc.to_tuple.should eq({0, 0, 0, 9})
 
       mod = mod.expr.should be_a LC::TypeModifier
       mod.kind.abstract?.should be_true
@@ -506,12 +511,14 @@ describe LC::Parser do
     it "errors on duplicate visibility keywords on method defs" do
       mod = parse("private private def foo; end").should be_a LC::TypeModifier
       mod.kind.private?.should be_true
+      mod.loc.to_tuple.should eq({0, 0, 0, 7})
 
       error = mod.expr.should be_a LC::Error
       error.message.should eq "cannot apply private to private"
 
       mod = error.target.should be_a LC::TypeModifier
       mod.kind.private?.should be_true
+      mod.loc.to_tuple.should eq({0, 8, 0, 15})
 
       node = mod.expr.should be_a LC::Def
       ident = node.name.should be_a LC::Ident
@@ -519,12 +526,14 @@ describe LC::Parser do
 
       mod = parse("protected protected def bar; end").should be_a LC::TypeModifier
       mod.kind.protected?.should be_true
+      mod.loc.to_tuple.should eq({0, 0, 0, 9})
 
       error = mod.expr.should be_a LC::Error
       error.message.should eq "cannot apply protected to protected"
 
       mod = error.target.should be_a LC::TypeModifier
       mod.kind.protected?.should be_true
+      mod.loc.to_tuple.should eq({0, 10, 0, 19})
 
       node = mod.expr.should be_a LC::Def
       ident = node.name.should be_a LC::Ident
@@ -532,12 +541,14 @@ describe LC::Parser do
 
       mod = parse("abstract abstract def baz").should be_a LC::TypeModifier
       mod.kind.abstract?.should be_true
+      mod.loc.to_tuple.should eq({0, 0, 0, 8})
 
       error = mod.expr.should be_a LC::Error
       error.message.should eq "cannot apply abstract to abstract"
 
       mod = error.target.should be_a LC::TypeModifier
       mod.kind.abstract?.should be_true
+      mod.loc.to_tuple.should eq({0, 9, 0, 17})
 
       node = mod.expr.should be_a LC::Def
       ident = node.name.should be_a LC::Ident
@@ -547,12 +558,14 @@ describe LC::Parser do
     it "errors on private-protected keywords on method defs" do
       mod = parse("private protected def foo; end").should be_a LC::TypeModifier
       mod.kind.private?.should be_true
+      mod.loc.to_tuple.should eq({0, 0, 0, 7})
 
       error = mod.expr.should be_a LC::Error
       error.message.should eq "cannot apply private to protected"
 
       mod = error.target.should be_a LC::TypeModifier
       mod.kind.protected?.should be_true
+      mod.loc.to_tuple.should eq({0, 8, 0, 17})
 
       node = mod.expr.should be_a LC::Def
       ident = node.name.should be_a LC::Ident

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -8,11 +8,6 @@ def parse(source : String, file : String = "STDIN", dir : String = "") : LC::Nod
   LC::Parser.parse(tokens).nodes[0]
 end
 
-def parse_all(source : String) : Array(LC::Node)
-  tokens = LC::Lexer.run source
-  LC::Parser.parse(tokens).nodes
-end
-
 def assert_node(cls : LC::Node.class, for input : String) : Nil
   parse(input).class.should eq cls
 end

--- a/src/compiler/node.cr
+++ b/src/compiler/node.cr
@@ -54,6 +54,40 @@ module Lucid::Compiler
     end
   end
 
+  class TypeModifier < Node
+    enum Kind
+      Abstract
+      Private
+      Protected
+    end
+
+    property kind : Kind
+    property expr : Node
+
+    def initialize(@kind : Kind, @expr : Node)
+      super()
+    end
+
+    def to_s(io : IO) : Nil
+      io << @kind.to_s.downcase << ' '
+      @expr.to_s io
+    end
+
+    def pretty_print(pp : PrettyPrint) : Nil
+      pp.text "TypeModifier("
+      pp.group 1 do
+        pp.breakable ""
+        pp.text "kind: "
+        @kind.pretty_print pp
+        pp.comma
+
+        pp.text "expr: "
+        @expr.pretty_print pp
+      end
+      pp.text ")"
+    end
+  end
+
   abstract class NamespaceDef < Node
     property name : Node
     property free_vars : Array(Node)

--- a/src/compiler/parser.cr
+++ b/src/compiler/parser.cr
@@ -173,7 +173,7 @@ module Lucid::Compiler
     end
 
     private def parse_type_modifier_expression(token : Token) : Node
-      start = token.loc
+      loc = token.loc
       kind = case token.kind
              when .abstract?
                TypeModifier::Kind::Abstract
@@ -201,7 +201,7 @@ module Lucid::Compiler
         expr = raise current_token, "unexpected end of file"
       end
 
-      TypeModifier.new(kind, expr).at(start & expr.loc)
+      TypeModifier.new(kind, expr).at(loc)
     end
 
     # TODO: might be worth merging with below and erroring on inheritance

--- a/src/compiler/parser.cr
+++ b/src/compiler/parser.cr
@@ -192,7 +192,12 @@ module Lucid::Compiler
         expr = parse token
       end
 
-      if expr.nil?
+      case expr
+      when TypeModifier
+        unless (kind.private? || kind.protected?) && expr.kind.abstract?
+          expr = raise expr, "cannot apply #{kind.to_s.downcase} to #{expr.kind.to_s.downcase}"
+        end
+      when Nil
         expr = raise current_token, "unexpected end of file"
       end
 


### PR DESCRIPTION
Alternative to `VisibilityModifier` in the Crystal compiler, as this includes `abstract` which doesn't change visibility of a type. Closes #55.